### PR TITLE
fix transmission-remote authentication

### DIFF
--- a/tremc
+++ b/tremc
@@ -3651,6 +3651,12 @@ if __name__ == '__main__':
     # read config from config file
     config.read(cmd_args.configfile)
 
+    un_pw = os.environ.get("TR_AUTH")
+    if un_pw:
+        username = un_pw.split(":")[0]
+        password = ":".join(un_pw.split(":")[1:])
+        config.set('Connection', 'username', username)
+        config.set('Connection', 'password', password)
     # command line connection data can override config file
     if cmd_args.connection:
         host, port, path, username, password = explode_connection_string(cmd_args.connection)
@@ -3675,10 +3681,8 @@ if __name__ == '__main__':
 
         # transmission-remote requires --auth or --authenv before any other
         # parameters which require authentication. Otherwise, auth fails.
-        if os.environ.get("TR_AUTH"):
-            cmd.extend(['--authenv'])
-        elif (config.get('Connection', 'username') and
-              config.get('Connection', 'password')):
+        if (config.get('Connection', 'username') and
+            config.get('Connection', 'password')):
             os.environ["TR_AUTH"] = "{0}:{1}".format(
                 config.get('Connection', 'username'),
                 config.get('Connection', 'password'))

--- a/tremc
+++ b/tremc
@@ -3673,19 +3673,24 @@ if __name__ == '__main__':
         if find_executable(cmd[0]) is None:
             quit("Command not found: %s\n" % cmd[0], 128)
 
+        # transmission-remote requires --auth or --authenv before any other
+        # parameters which require authentication. Otherwise, auth fails.
+        if os.environ.get("TR_AUTH"):
+            cmd.extend(['--authenv'])
+        elif (config.get('Connection', 'username') and
+              config.get('Connection', 'password')):
+            os.environ["TR_AUTH"] = "{0}:{1}".format(
+                config.get('Connection', 'username'),
+                config.get('Connection', 'password'))
+            cmd.extend(['--authenv'])
+
         # one argument and it doesn't start with '-' --> treat it like it's a torrent link/url
         if len(transmissionremote_args) == 1 and not transmissionremote_args[0].startswith('-'):
             cmd.extend(['-a', transmissionremote_args[0]])
         else:
             cmd.extend(transmissionremote_args)
 
-        if config.get('Connection', 'username') and config.get('Connection', 'password'):
-            cmd_print = cmd
-            cmd_print.extend(['--auth', '%s:PASSWORD' % config.get('Connection', 'username')])
-            print("EXECUTING:\n%s\nRESPONSE:" % ' '.join(cmd_print))
-            cmd.extend(['--auth', '%s:%s' % (config.get('Connection', 'username'), config.get('Connection', 'password'))])
-        else:
-            print("EXECUTING:\n%s\nRESPONSE:" % ' '.join(cmd))
+        print("EXECUTING:\n%s\nRESPONSE:" % ' '.join(cmd))
 
         try:
             retcode = call(cmd)


### PR DESCRIPTION
Some transmission-remote options fail if the --auth or --authenv options
are not given in earlier order on the command line. This patch fixes
this by setting --authenv before any other options.

Additionally, --authenv is used and TR_AUTH is set even when reading the
password from the config. This is better because if the password is
given as a command line argument, it is visible by any user on the
system. (For example in the output of "ps aux").

Closes #18