### PR TITLE
fix 'add' so that we send correct data to daemon

### DIFF
--- a/tremc
+++ b/tremc
@@ -646,7 +646,7 @@ class Transmission(object):
         args = {}
         try:
             with  open(location, 'rb') as fp:
-                args['metainfo'] = str(base64.b64encode(fp.read()))
+                args['metainfo'] = base64.b64encode(fp.read()).decode()
         # If the file doesnt exist or we cant open it, then it is either a url or needs to
         # be open by the server
         except IOError:


### PR DESCRIPTION
We were converting a byte object to str with str() but now we are
properly using bytes.decode().
This was a victim of the 2to3 automatic conversion.

This  is probably a common issue with python2->3 conversions. If
you're not sure what the big deal is just do
print(str(some_bytes_object)). Then compare it to
print(some_bytes_object.decode()). It should be obvious at that point.

Fixes #6