### PR TITLE
More bindings

### DIFF
--- a/tremc
+++ b/tremc
@@ -905,6 +905,7 @@ class Interface(object):
         self.keybindings = {
             ord('?'):               self.call_list_key_bindings,
             curses.KEY_F1:          self.call_list_key_bindings,
+            7:                      self.go_back_or_unfocus,
             27:                     self.go_back_or_unfocus,
             curses.KEY_BREAK:       self.go_back_or_unfocus,
             12:                     self.go_back_or_unfocus,
@@ -2925,7 +2926,7 @@ class Interface(object):
                 input = False
             elif c == ord("\n") or c == ord(' '):
                 return input
-            elif c == 27 or c == curses.KEY_BREAK:
+            elif c in (27, 7, curses.KEY_BREAK):
                 return -1
 
     def dialog_input_text(self, message, input='', on_change=None, on_enter=None, tab_complete=None):
@@ -2957,7 +2958,7 @@ class Interface(object):
             win.addstr(height - 2, 2, displaytext.ljust(textwidth), color)
             win.move(height - 2, displayindex + 2)
             c = win.getch()
-            if c == 27 or c == curses.KEY_BREAK:
+            if c in (27, 7, curses.KEY_BREAK):
                 hide_cursor()
                 return ''
             elif index < len(input) and ( c == curses.KEY_RIGHT or c == curses.ascii.ctrl(ord('f')) ):
@@ -3062,7 +3063,7 @@ class Interface(object):
             win.addstr(height-2, 2, input.ljust(width-4), curses.color_pair(self.colors.id('dialog')))
             win.move(height - 2, len(input) + 2)
             c = win.getch()
-            if c == 27 or c == ord('q') or c == curses.KEY_BREAK:
+            if c in (27, 7, ord('q'), curses.KEY_BREAK):
                 hide_cursor()
                 return -128
             elif c == ord("\n"):
@@ -3127,7 +3128,7 @@ class Interface(object):
 
             if c > 96 and c < 123 and chr(c) in keymap:
                 return options[keymap[chr(c)]][0]
-            elif c == 27 or c == ord('q'):
+            elif c in (27, 7, ord('q')):
                 return -128
             elif c == ord("\n"):
                 return options[focus-1][0]
@@ -3200,7 +3201,7 @@ class Interface(object):
                 line_num += 1
 
             c = win.getch()
-            if c == 27 or c == ord('q') or c == ord("\n"):
+            if c in (27, 7, ord('q'), ord("\n")):
                 return
             elif c == ord('p'):
                 port = self.dialog_input_number("Port for incoming connections",

--- a/tremc
+++ b/tremc
@@ -953,6 +953,8 @@ class Interface(object):
             curses.ascii.ctrl(ord('b')): self.movement_keys,
             curses.ascii.ctrl(ord('n')): self.movement_keys,
             curses.ascii.ctrl(ord('p')): self.movement_keys,
+            curses.ascii.ctrl(ord('d')): self.movement_keys,
+            curses.ascii.ctrl(ord('u')): self.movement_keys,
             ord("\t"):              self.move_in_details,
             curses.KEY_BTAB:        self.move_in_details,
             ord('e'):               self.move_in_details,
@@ -1504,10 +1506,10 @@ class Interface(object):
             elif c == curses.KEY_DOWN or c == ord('j') or c == curses.ascii.ctrl(ord('n')):
                 self.focus, self.scrollpos = self.move_down(self.focus, self.scrollpos, self.tlist_item_height,
                                                             self.torrents_per_page, len(self.torrents))
-            elif c == curses.KEY_PPAGE or c == curses.ascii.ctrl(ord('b')):
+            elif c == curses.KEY_PPAGE or c == curses.ascii.ctrl(ord('b')) or c == curses.ascii.ctrl(ord('u')):
                 self.focus, self.scrollpos = self.move_page_up(self.focus, self.scrollpos, self.tlist_item_height,
                                                                self.torrents_per_page)
-            elif c == curses.KEY_NPAGE or c == curses.ascii.ctrl(ord('f')):
+            elif c == curses.KEY_NPAGE or c == curses.ascii.ctrl(ord('f')) or c == curses.ascii.ctrl(ord('d')):
                 self.focus, self.scrollpos = self.move_page_down(self.focus, self.scrollpos, self.tlist_item_height,
                                                                  self.torrents_per_page, len(self.torrents))
             elif c == curses.KEY_HOME or c == ord('g'):

--- a/tremc
+++ b/tremc
@@ -1506,11 +1506,17 @@ class Interface(object):
             elif c == curses.KEY_DOWN or c == ord('j') or c == curses.ascii.ctrl(ord('n')):
                 self.focus, self.scrollpos = self.move_down(self.focus, self.scrollpos, self.tlist_item_height,
                                                             self.torrents_per_page, len(self.torrents))
-            elif c == curses.KEY_PPAGE or c == curses.ascii.ctrl(ord('b')) or c == curses.ascii.ctrl(ord('u')):
+            elif c == curses.KEY_PPAGE or c == curses.ascii.ctrl(ord('u')):
                 self.focus, self.scrollpos = self.move_page_up(self.focus, self.scrollpos, self.tlist_item_height,
                                                                self.torrents_per_page)
-            elif c == curses.KEY_NPAGE or c == curses.ascii.ctrl(ord('f')) or c == curses.ascii.ctrl(ord('d')):
+            elif c == curses.KEY_NPAGE or c == curses.ascii.ctrl(ord('d')):
                 self.focus, self.scrollpos = self.move_page_down(self.focus, self.scrollpos, self.tlist_item_height,
+                                                                 self.torrents_per_page, len(self.torrents))
+            elif c == curses.ascii.ctrl(ord('f')):
+                self.focus, self.scrollpos = self.scroll_line_down(self.focus, self.scrollpos, self.tlist_item_height,
+                                                                   self.torrents_per_page, len(self.torrents))
+            elif c == curses.ascii.ctrl(ord('b')):
+                self.focus, self.scrollpos = self.scroll_line_up(self.focus, self.scrollpos, self.tlist_item_height,
                                                                  self.torrents_per_page, len(self.torrents))
             elif c == curses.KEY_HOME or c == ord('g'):
                 self.focus, self.scrollpos = self.move_to_top()
@@ -2615,6 +2621,18 @@ class Interface(object):
         if focus < 0: focus = 0
         for x in range(elements_per_page - 1):
             focus, scrollpos = self.move_down(focus, scrollpos, step_size, elements_per_page, list_height)
+        return focus, scrollpos
+
+    def scroll_line_down(self, focus, scrollpos, step_size, elements_per_page, list_height):
+        if focus < 0: focus = 0
+        if focus > scrollpos/step_size:
+            # when focus isn't at the top of the view.
+            scrollpos += step_size
+        return focus, scrollpos
+
+    def scroll_line_up(self, focus, scrollpos, step_size, elements_per_page, list_height):
+        if focus - scrollpos/step_size < elements_per_page:
+            scrollpos -= step_size
         return focus, scrollpos
 
     def move_to_top(self):


### PR DESCRIPTION
closes #53 

summary of changes:
- `C-g` can be used anywhere `escape` is used.
- `C-b` remapped to `C-u`.
- `C-f` remapped to `C-d`.
- `C-b` mapped to new command `scroll-line-down` [1].
- `C-f` mapped to new command `scroll-line-up` [2].

[1] scrolls around the focused entry, without changing the focused entry. The best way to explain is to try it out.
[2] similarly scrolls up without changing focused entry.

WARN: there might be an issue with the new `scroll-line-*` commands when you've got fewer torrents than the number tremc shows per page. I didn't know how to test this without removing all my torrents, so if someone could verify it works with them I'd much appreciate it.