### PR TITLE
Replace deprecated decodestring with decodebytes

### DIFF
--- a/tremc
+++ b/tremc
@@ -438,7 +438,7 @@ class Transmission(object):
                 # TAG_TORRENT_DETAILS, but just passing seems to help.(?)
                 try:
                     torrent_details = response['arguments']['torrents'][0]
-                    torrent_details['pieces'] = base64.decodestring(bytes(torrent_details['pieces'], ENCODING))
+                    torrent_details['pieces'] = base64.decodebytes(bytes(torrent_details['pieces'], ENCODING))
                     self.torrent_details_cache = torrent_details
                     self.upgrade_peerlist()
                 except IndexError:


### PR DESCRIPTION
As per the [python docs](https://docs.python.org/3.8/library/base64.html#base64.decodestring) `decodestring` is a deprecated function that is an alias to `decodebytes`.

On my machine I get warnings when this happens and it screws up the tui.