### PR TITLE
fix bug where queuePosition sort in config is ignored

### DIFF
--- a/tremc
+++ b/tremc
@@ -651,6 +651,11 @@ class Transmission:
             self.LIST_FIELDS.append('labels')
             self.DETAIL_FIELDS.append('labels')
 
+        # queue was implemmented in transmission 2.4
+        if self.rpc_version < 14:
+            gconfig.sort_options.remove(('queuePosition', '_Queue Position'))
+            gconfig.sort_orders = [{'name': 'name', 'reverse': True}] # assume optimistically that 'name' is a valid sorting order key
+
         # set up request list
         self.requests = {'torrent-list':
                          TransmissionRequest(url, 'torrent-get', self.TAG_TORRENT_LIST, {'fields': self.LIST_FIELDS}, server=self),

--- a/tremc
+++ b/tremc
@@ -188,7 +188,7 @@ class GConfig:
             ('rateUpload', '_Upload Speed'), ('rateDownload', '_Download Speed'),
             ('uploadRatio', '_Ratio'), ('peersConnected', 'P_eers'),
             ('downloadDir', 'L_ocation'), ('mainTrackerDomain', 'Trac_ker'),
-            ('reverse', 'Re_verse')]
+            ('queuePosition', '_Queue Position'), ('reverse', 'Re_verse') ]
         self.file_sort_options = [
             ('name', '_Name'), ('progress', '_Progress'),
             ('length', 'Si_ze'), ('bytesCompleted', '_Downloaded'),
@@ -1285,10 +1285,6 @@ class Interface:
         set_keys(gconfig.actions, self.common_keybindings, [0], self)
         set_keys(gconfig.actions, self.list_keybindings, [1], self)
         set_keys(gconfig.actions, self.details_keybindings, [2, 3, 4], self)
-
-        # queue was implemmented in transmission 2.4
-        if self.server.get_rpc_version() >= 14:
-            gconfig.sort_options.insert(-1, ('queuePosition', '_Queue Position'))
 
         self.filelist_needs_refresh = False
         self.sorted_files = None


### PR DESCRIPTION
Queue was implemented in rpc version 14. The code checked for rpc
version >= 14 and tried to then enable queuePosition sort but this
happened after the config was parsed. Checking before the config is
parsed is not possible because the connection to the server is not
established that early.

This fix removes the check entirely. This means that for users who use
queuePosition sort in their configs and then downgrade for some reason
to an older transmission-daemon version, tremc will likely crash with an
exception.

This will not break any existing configs of old installations and for
this reason I consider it an acceptable fix, in the interest of time and
less code complexity.

fixes #64