### PR TITLE
Text input corrections and improvements

### DIFF
--- a/tremc
+++ b/tremc
@@ -3793,6 +3793,9 @@ class Interface:
             if c in gconfig.esc_keys_w_no_ascii:
                 hide_cursor()
                 return ''
+            if c == K.X_:
+                text = ''
+                index = 0
             if index < len(text) and (c in (curses.KEY_RIGHT, K.F_)):
                 index += 1
             elif index > 0 and (c in (curses.KEY_LEFT, K.B_)):
@@ -4047,6 +4050,8 @@ class Interface:
 
             elif c in (curses.KEY_BACKSPACE, curses.KEY_DC, K.DEL, 8):
                 value = value[:-1]
+            elif c in (K.U_, K.X_):
+                value = ''
             elif len(value) >= width - 5:
                 curses.beep()
             elif K.n1 <= c <= K.n9:

--- a/tremc
+++ b/tremc
@@ -3833,6 +3833,7 @@ class Interface:
                     else:
                         inc = 0
                     if on_enter(text, inc=inc, search=search):
+                        hide_cursor()
                         return None
                 else:
                     hide_cursor()

--- a/tremc
+++ b/tremc
@@ -2221,9 +2221,17 @@ class Interface:
                 self.get_screen_size()
                 self.dialog_ok("%s:\n%s" % (" ".join(viewer_cmd), err))
             hide_cursor()
+            if gconfig.file_viewer != file_viewer:
+                file_type = self.server.get_torrent_details()['files'][self.file_index_map[self.focus_detaillist]]['name'].split('.')[-1]
+                gconfig.histories['types'][file_type] = file_viewer
 
     def action_view_file_command(self):
-        self.dialog_input_text('Command to run (%s will be replaced by file name)',
+        file_type = self.server.get_torrent_details()['files'][self.file_index_map[self.focus_detaillist]]['name'].split('.')[-1]
+        if file_type in gconfig.histories['types']:
+            command = gconfig.histories['types'][file_type]
+        else:
+            command = ''
+        self.dialog_input_text('Command to run (%s will be replaced by file name)', command,
                                tab_complete='executable',
                                on_enter=self.view_file_command,
                                history=gconfig.histories['command'], history_max=10,
@@ -4484,6 +4492,8 @@ def load_history(filename):
     for i in ['label', 'location', 'tracker', 'command']:
         if i not in history:
             history[i] = []
+    if 'types' not in history:
+        history['types'] = {}
     return history
 
 

--- a/tremc
+++ b/tremc
@@ -2464,6 +2464,7 @@ class Interface:
                 curses.beep()
         else:
             self.search_focus = 0
+            self.highlight_dialog = False
 
         self.follow_list_focus()
         self.manage_layout()
@@ -2926,6 +2927,7 @@ class Interface:
                 curses.beep()
         else:
             self.search_focus = 0
+            self.highlight_dialog = False
         self.draw_filelist(5, needclrtoeol=True)
         self.pad.refresh(0, 0, 1, 0, self.height - 2, self.width)
         self.screen.refresh()

--- a/tremc
+++ b/tremc
@@ -2220,6 +2220,7 @@ class Interface:
             except OSError as err:
                 self.get_screen_size()
                 self.dialog_ok("%s:\n%s" % (" ".join(viewer_cmd), err))
+            hide_cursor()
 
     def action_view_file_command(self):
         self.dialog_input_text('Command to run (%s will be replaced by file name)',


### PR DESCRIPTION
1. Fix to visual artefacts
2. Add a shortcut (^X) to clear the input field
3. Remember the last viewer for each file type, and offer it first.