### PR TITLE
Two commits to improve performance in torrent details view

### DIFF
--- a/tremc
+++ b/tremc
@@ -1357,11 +1357,12 @@ class Interface:
             else:
                 break
         self.manage_layout()
+        # There are two extra lines here: One for a possible invisible line of
+        # the last torrent, the other for avoiding 'last char of window bug'.
+        self.pad = curses.newpad(self.height, self.width)
 
     def manage_layout(self):
         self.recalculate_torrents_per_page()
-        self.pad_height = max((len(self.torrents) + 1) * gconfig.tlist_item_height, self.height)
-        self.pad = curses.newpad(self.pad_height, self.width)
         self.detaillines_per_page = self.height - 8
         self.narrow = self.width < 73
 
@@ -1374,8 +1375,8 @@ class Interface:
                 self.torrent_title_width -= self.rateDownload_width + 2
 
         elif self.torrents:
-            self.visible_torrents_start = self.scrollpos / gconfig.tlist_item_height
-            self.visible_torrents = self.torrents[int(self.visible_torrents_start): int(self.scrollpos / gconfig.tlist_item_height + self.torrents_per_page + 1)]
+            self.visible_torrents_start = self.scrollpos // gconfig.tlist_item_height
+            self.visible_torrents = self.torrents[self.visible_torrents_start: self.visible_torrents_start + self.torrents_per_page]
             self.rateDownload_width = self.get_rateDownload_width(self.visible_torrents)
             self.rateUpload_width = self.get_rateUpload_width(self.visible_torrents)
             self.torrent_title_width = self.width - self.rateUpload_width - 2
@@ -1402,7 +1403,7 @@ class Interface:
 
     def recalculate_torrents_per_page(self):
         self.mainview_height = self.height - 2
-        self.torrents_per_page = self.mainview_height // gconfig.tlist_item_height
+        self.torrents_per_page = (self.mainview_height + gconfig.tlist_item_height - 1) // gconfig.tlist_item_height
 
     def run(self):
         self.draw_title_bar()
@@ -2467,6 +2468,7 @@ class Interface:
 
         self.follow_list_focus()
         self.manage_layout()
+        self.pad.erase()
 
         ypos = 0
         for i in range(len(self.visible_torrents)):
@@ -2680,10 +2682,7 @@ class Interface:
     def draw_details(self, search_keyword=None, search='', refresh=True):
         self.torrent_details = self.server.get_torrent_details()
         self.manage_layout()
-
-        # details could need more space than the torrent list
-        self.pad_height = max(50, len(self.torrent_details['files']) + 10, (len(self.torrents) + 1) * 3, self.height)
-        self.pad = curses.newpad(self.pad_height, self.width)
+        self.pad.erase()
 
         # torrent name + progress bar
         self.draw_torrentlist_item(self.torrent_details, False, False, 0)
@@ -2718,7 +2717,7 @@ class Interface:
             self.draw_pieces_map(5)
 
         if refresh:
-            self.pad.refresh(0, 0, 1, 0, self.height - 2, self.width)
+            self.pad.refresh(0, 0, 1, 0, self.mainview_height, self.width)
             self.screen.refresh()
 
     def draw_details_overview(self, ypos):
@@ -3332,6 +3331,8 @@ class Interface:
                     self.pad.addnstr(v, self.width - value_x)
                 xp += len(v)
             yp += 1
+            if yp > self.mainview_height:
+                return yp
         return yp
 
     def action_next_details(self):

--- a/tremc
+++ b/tremc
@@ -3242,34 +3242,53 @@ class Interface:
             ypos += 7
 
     def draw_pieces_map(self, ypos):
+        if self.torrent_details['haveValid'] / self.torrent_details['totalSize'] < 0.5:
+            default_attr = 0
+            new_attr = curses.A_REVERSE
+            change_attr = 0x80
+            skip_run = 0
+        else:
+            new_attr = 0
+            default_attr = curses.A_REVERSE
+            change_attr = 0
+            skip_run = 255
         pieces = self.torrent_details['pieces']
         piece_count = self.torrent_details['pieceCount']
         margin = len(str(piece_count)) + 2
-        piece_attrs = {0: ('-', 0), 0x80: ('-', curses.A_REVERSE)}
+        map_width = (self.width - margin - 1) // 10 * 10
+        start = self.scrollpos_detaillist[4] * map_width
+        end = min(start + (self.height - ypos - 3) * map_width, piece_count)
+        last_line = (end - 1) // map_width
+        if end <= start:
+            return
 
-        map_width = int(str(self.width - margin - 1)[0:-1] + '0')
         for x in range(10, map_width, 10):
             self.pad.addstr(ypos, x + margin - 1, str(x), curses.A_BOLD)
 
-        start = self.scrollpos_detaillist[4] * map_width
-        end = min(start + (self.height - ypos - 3) * map_width, piece_count)
-        if end <= start:
-            return
-        block = (pieces[start >> 3]) << (start & 7)
-
         format_str = "%%%dd" % (margin - 2)
-        for counter in range(start, end):
-            if counter % map_width == 0:
-                ypos += 1
-                xpos = margin
-                self.pad.addstr(ypos, 1, format_str % counter, curses.A_BOLD)
+        yp = ypos + 1
+        for counter in range(self.scrollpos_detaillist[4], last_line + 1):
+            self.pad.addstr(yp, 1, format_str % (counter * map_width), curses.A_BOLD)
+            if counter == last_line:
+                self.pad.addstr(yp, margin, '-' * ((end - 1) % map_width + 1), default_attr)
             else:
-                xpos += 1
+                self.pad.addstr(yp, margin, '-' * map_width, default_attr)
+            yp = yp + 1
 
+        counter = start
+        block = (pieces[start >> 3]) << (start & 7)
+        while counter < end:
             if counter & 7 == 0:
                 block = (pieces[counter >> 3])
-            self.pad.addch(ypos, xpos, *piece_attrs[block & 0x80])
+                while block == skip_run and counter < end - 8:
+                    counter += 8
+                    block = (pieces[counter >> 3])
+            if block & 0x80 == change_attr:
+                self.pad.chgat(ypos + 1 + (counter-start) // map_width, margin + (counter-start) % map_width, 1, new_attr)
             block <<= 1
+            counter += 1
+        if counter >= end:
+            counter = end - 1
 
         missing_pieces = piece_count - counter - 1
         if missing_pieces:


### PR DESCRIPTION
1. File list - by avoiding creation of a new curses pad for each redraw. This allows tremc running on a 1GHz ARM Cortex-A7 over ssh to scroll a list of 2000 files at the speed of the keyboard autorepeat, which is impossible without this change.

2. Chunks list - instead of addch() each chararcter, use addstr() for each line, and then change attributes of chunks that are in the minority. This works best when the torrent is close to 0% or 100%, but improves performance even when torrent is around 50%.