### PR TITLE
Workaround for exit code

### DIFF
--- a/tremc
+++ b/tremc
@@ -4727,13 +4727,19 @@ def num2str(num, num_format='%s'):
     return num_format % num
 
 
+lastexitcode = -1
 def exit_prog(msg='', exitcode=0):
+    global lastexitcode
     try:
         curses.endwin()
     except curses.error:
         pass
     if msg or exitcode:
         print(msg, file=sys.stderr)
+    if lastexitcode == -1:
+        lastexitcode = exitcode
+    elif exitcode == 0:
+        exitcode = lastexitcode
     sys.exit(exitcode)
 
 


### PR DESCRIPTION
Python exits by SyetemExit exception, so catching using try...finally to make sure screen mode is restored at exit catches the exit and loses the exit code.
This is a workaround to save the exit code from the first (intentional) call to exit_prog for the second call in the finally clause to use.

This should solve https://github.com/tremc/tremc/issues/74