### PR TITLE
Fix display of locations/labels/trackers with _ in menus

### DIFF
--- a/tremc
+++ b/tremc
@@ -4169,7 +4169,7 @@ class Interface:
         keys = dict()
         i = 1
         for option in options:
-            title = option[1].split('_')
+            title = option[1].split('_', 1)
             if startline < i <= endline:
                 if i == focus:
                     win.bkgdset(win.getbkgd() - curses.A_REVERSE)


### PR DESCRIPTION
This commit only splits on the first _ in a menu string (which comes from
a shortcut key in the filtering menu for those items), so that the item name
will be displayed completely, even if it contains _.

This should solve https://github.com/tremc/tremc/issues/76 .

Note that only the first 26 items in each menu get a key shortcut, so items
from the 27th and after that contain _ will still not be displayed correctly,
but this should be good enough for now.