### PR TITLE
Remove queuePosition from sort options if server has no queue

### DIFF
--- a/tremc
+++ b/tremc
@@ -652,6 +652,11 @@ class Transmission:
         if self.rpc_version >= 14:
             self.LIST_FIELDS.append('queuePosition')
             self.DETAIL_FIELDS.append('queuePosition')
+        else:
+            gconfig.sort_options.remove(('queuePosition', '_Queue Position'))
+            if gconfig.sort_orders[0]['name'] == 'queuePosition':
+                # Use default sort if set to invalid queuePosition.
+                gconfig.sort_orders = [{'name': 'name', 'reverse': False}]
 
         if self.rpc_version >= 16:
             self.LIST_FIELDS.append('labels')


### PR DESCRIPTION
This completes https://github.com/tremc/tremc/commit/61dae8dfb9ef88376e154a0ca1122ddee1321946 .

By default, queuePosition is in sort_options so that it may be used in the config file, which
is parsed before connecting to the server. If after connecting we see the server does not support
this feature, we remove it from the options and reset the sort order to the default sort order
if it was set in the config file to queuePosition.