### PR TITLE
Make more UI colors configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,17 +296,17 @@ The following sections are read:
   The format of a color is 'fg:color,bg:color', where each color is one of the
   eight curses colors, or default.
 
-  Allowed elements are title_seed, title_download, title_idle, title_verify, title_paused, title_error,
-  download_rate, upload_rate, eta+ratio, filter_status, multi_filter_status, dialog, dialog_important,
-  file_prio_high, file_prio_normal, file_prio_low, file_prio_off.
+  Allowed elements are header, footer, selection,title_seed, title_download, title_idle, title_incomplete, title_verify,
+  title_paused, title_error, download_rate, upload_rate, eta+ratio, filter_status, multi_filter_status, 
+  window, dialog, dialog_important, file_prio_high, file_prio_normal, file_prio_low, file_prio_off.
 
   Note that what the colors mean actually depends on the terminal. In some
   cases 'white' is darker then the white that the terminal displays, and
   similarly, 'black' is lighter. Setting 'default' selects the respective
   background or foreground coloe of the terminal.
 
-  The top and bottom status lines (filter_status, multi_filter_status) and the dialog window
-  (dialog, dialog_important) are displayed using inverse mode, so the fg and bg
+  The top and bottom status lines (header, footer, filter_status, multi_filter_status) and the dialog window
+  (window, dialog, dialog_important) are displayed using inverse mode, so the fg and bg
   are exchanged.
 * [Profiles]
 

--- a/tremc
+++ b/tremc
@@ -416,6 +416,7 @@ config.set('Misc', 'file_open_in_terminal', 'True')
 config.add_section('Colors')
 config.set('Colors', 'header', 'bg:default,fg:default')
 config.set('Colors', 'footer', 'bg:default,fg:default')
+config.set('Colors', 'selection', 'bg:default,fg:default')
 config.set('Colors', 'title_seed', 'bg:green,fg:black')
 config.set('Colors', 'title_download', 'bg:blue,fg:black')
 config.set('Colors', 'title_idle', 'bg:cyan,fg:black')
@@ -2542,7 +2543,7 @@ class Interface:
 
     def draw_downloadrate(self, torrent, ypos, selected):
         if selected:
-            tag = curses.A_REVERSE
+            tag = curses.color_pair(self.colors.ind('selection')) + curses.A_REVERSE
         else:
             tag = curses.color_pair(self.colors.ind('download_rate')) + curses.A_BOLD
         self.pad.move(ypos, self.width - self.rateDownload_width - self.rateUpload_width - 3)
@@ -2552,7 +2553,7 @@ class Interface:
 
     def draw_uploadrate(self, torrent, ypos, selected):
         if selected:
-            tag = curses.A_REVERSE
+            tag = curses.color_pair(self.colors.ind('selection')) + curses.A_REVERSE
         else:
             tag = curses.color_pair(self.colors.ind('upload_rate')) + curses.A_BOLD
         self.pad.move(ypos, self.width - self.rateUpload_width - 1)
@@ -2562,7 +2563,7 @@ class Interface:
 
     def draw_ratio(self, torrent, ypos, selected):
         if selected:
-            tag = curses.A_REVERSE
+            tag = curses.color_pair(self.colors.ind('selection')) + curses.A_REVERSE
         else:
             tag = curses.color_pair(self.colors.ind('eta+ratio')) + curses.A_BOLD
         self.pad.addch(ypos + 1, self.width - self.rateUpload_width - 1, curses.ACS_BULLET,
@@ -2633,6 +2634,7 @@ class Interface:
         tag = curses.A_REVERSE
         tag_done = color
         if focused:
+            tag += curses.color_pair(self.colors.ind('selection'))
             tag += curses.A_BOLD
             tag_done += curses.A_BOLD
 
@@ -2701,7 +2703,7 @@ class Interface:
                                                            ('s', ' ')[torrent['peersConnected'] == 1]))
 
         if focused:
-            tags = curses.A_REVERSE + curses.A_BOLD
+            tags = curses.color_pair(self.colors.ind('selection')) + curses.A_REVERSE + curses.A_BOLD
         else:
             tags = 0
 
@@ -2732,7 +2734,7 @@ class Interface:
             self.pad.move(3, xpos)
             tags = curses.A_BOLD
             if menu_items.index(item) == self.details_category_focus:
-                tags += curses.A_REVERSE
+                tags += curses.color_pair(self.colors.ind('selection')) + curses.A_REVERSE
             title = item.split('_')
             self.pad.addstr(title[0], tags)
             self.pad.addstr(title[1][0], tags + curses.A_UNDERLINE)
@@ -2981,7 +2983,7 @@ class Interface:
                     curses_tags = gconfig.selected_file_attr
                     line = line[2:]
                 if line[1] == 'F':
-                    curses_tags += curses.A_REVERSE
+                    curses_tags += curses.color_pair(self.colors.ind('selection')) + curses.A_REVERSE
                     line = line[2:]
                 try:
                     self.pad.addstr(ypos, 0, ' ' * self.width, curses_tags)
@@ -3246,7 +3248,7 @@ class Interface:
             if current_tier != t['tier']:
                 current_tier = t['tier']
 
-                tiercolor = curses.A_BOLD + curses.A_REVERSE \
+                tiercolor = curses.color_pair(self.colors.ind('selection')) + curses.A_BOLD + curses.A_REVERSE \
                     if selected else curses.A_REVERSE
                 addstr(ypos, 0, ("Tier %d" % (current_tier + 1)).ljust(self.width), tiercolor)
                 ypos += 1

--- a/tremc
+++ b/tremc
@@ -429,6 +429,7 @@ config.set('Colors', 'upload_rate', 'bg:black,fg:red')
 config.set('Colors', 'eta+ratio', 'bg:default,fg:default')
 config.set('Colors', 'filter_status', 'bg:red,fg:black')
 config.set('Colors', 'multi_filter_status', 'bg:blue,fg:black')
+config.set('Colors', 'window', 'bg:default,fg:default')
 config.set('Colors', 'dialog', 'bg:default,fg:default')
 config.set('Colors', 'dialog_important', 'bg:default,fg:red')
 config.set('Colors', 'file_prio_high', 'fg:red,bg:default')
@@ -3709,7 +3710,7 @@ class Interface:
         else:
             win.erase()
         win.box()
-        win.bkgd(' ', curses.A_REVERSE + curses.A_BOLD)
+        win.bkgd(' ', curses.color_pair(self.colors.ind('window')) + curses.A_REVERSE + curses.A_BOLD)
 
         if width >= 20:
             win.addch(height - 1, width - 19, curses.ACS_RTEE)

--- a/tremc
+++ b/tremc
@@ -414,6 +414,8 @@ config.set('Misc', 'torrentname_is_progressbar', 'True')
 config.set('Misc', 'file_viewer', 'xdg-open %%s')
 config.set('Misc', 'file_open_in_terminal', 'True')
 config.add_section('Colors')
+config.set('Colors', 'header', 'bg:default,fg:default')
+config.set('Colors', 'footer', 'bg:default,fg:default')
 config.set('Colors', 'title_seed', 'bg:green,fg:black')
 config.set('Colors', 'title_download', 'bg:blue,fg:black')
 config.set('Colors', 'title_idle', 'bg:cyan,fg:black')
@@ -3425,7 +3427,7 @@ class Interface:
 
     def draw_stats(self):
         try:
-            self.screen.addstr(self.height - 1, 0, ' '.center(self.width), curses.A_REVERSE)
+            self.screen.addstr(self.height - 1, 0, ' '.center(self.width), curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE)
         except curses.error:
             # curses can print to the last char (bottom right corner), but it raises an exception.
             pass
@@ -3443,9 +3445,9 @@ class Interface:
                                 + "PEX:%d " % self.torrent_details['peersFrom']['fromPex']
                                 + "Incoming:%d " % self.torrent_details['peersFrom']['fromIncoming']
                                 + "Cache:%d)" % self.torrent_details['peersFrom']['fromCache'])[:self.width-1],
-                               curses.A_REVERSE)
+                               curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE)
         elif self.vmode_id > -1:
-            self.screen.addstr((self.height - 1), 0, "-- VISUAL --", curses.A_REVERSE)
+            self.screen.addstr((self.height - 1), 0, "-- VISUAL --", curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE)
         else:
             if self.narrow:
                 strings = ['T', 'D', 'S', 'P', '', '!', ' ', ' S:%d', ' F:%d']
@@ -3453,24 +3455,24 @@ class Interface:
                 strings = ["Torrent%s:" % ('s', '')[len(self.torrents) == 1], "Downloading:", "Seeding:", "Paused:",
                            "Filter:", "not ", " Sort by:", " Selected:%d", " Files:%d"]
             self.screen.addstr((self.height - 1), 0, strings[0],
-                               curses.A_REVERSE)
-            self.screen.addstr("%d (" % len(self.torrents), curses.A_REVERSE)
+                               curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE)
+            self.screen.addstr("%d (" % len(self.torrents), curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE)
 
             downloading = len([x for x in self.torrents if x['status'] == Transmission.STATUS_DOWNLOAD])
             seeding = len([x for x in self.torrents if x['status'] == Transmission.STATUS_SEED])
             paused = len([x for x in self.torrents if x['status'] in [Transmission.STATUS_STOPPED, Transmission.STATUS_CHECK_WAIT,
                                                                       Transmission.STATUS_CHECK, Transmission.STATUS_DOWNLOAD_WAIT, Transmission.STATUS_SEED_WAIT]])
 
-            self.screen.addstr(strings[1], curses.A_REVERSE)
-            self.screen.addstr("%d " % downloading, curses.A_REVERSE)
-            self.screen.addstr(strings[2], curses.A_REVERSE)
-            self.screen.addstr("%d " % seeding, curses.A_REVERSE)
-            self.screen.addstr(strings[3], curses.A_REVERSE)
-            self.screen.addstr("%d) " % paused, curses.A_REVERSE)
+            self.screen.addstr(strings[1], curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE)
+            self.screen.addstr("%d " % downloading, curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE)
+            self.screen.addstr(strings[2], curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE)
+            self.screen.addstr("%d " % seeding, curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE)
+            self.screen.addstr(strings[3], curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE)
+            self.screen.addstr("%d) " % paused, curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE)
 
             if self.selected_torrent == -1:
                 if gconfig.filters[0][0]['name']:
-                    self.screen.addstr(strings[4], curses.A_REVERSE)
+                    self.screen.addstr(strings[4], curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE)
                     if not self.narrow and gconfig.filters[0][0]['name'] in gconfig.FILTERS_WITH_PARAM:
                         filter_param = ('=', '!=')[gconfig.filters[0][0]['inverse']] + gconfig.filters[0][0][gconfig.filters[0][0]['name']][-16:]
                         not_str = ''
@@ -3479,11 +3481,11 @@ class Interface:
                         not_str = ('', strings[5])[gconfig.filters[0][0]['inverse']]
                     self.screen.addstr(not_str + gconfig.filters[0][0]['name'] + filter_param,
                                        curses.color_pair(self.colors.ind('filter_status' if len(gconfig.filters[0]) <= 1 else 'multi_filter_status')) +
-                                       + (curses.A_REVERSE if not self.invert_filters else 0))
+                                       + (curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE if not self.invert_filters else 0))
 
                 # show last sort order (if terminal size permits it)
                 if gconfig.sort_orders and self.width - self.screen.getyx()[1] > 20:
-                    self.screen.addstr(strings[6], curses.A_REVERSE)
+                    self.screen.addstr(strings[6], curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE)
                     name = [name[1] for name in gconfig.sort_options if name[0] == gconfig.sort_orders[-1]['name']][0]
                     name = name.replace('_', '').lower()
                     curses_tags = curses.color_pair(self.colors.ind('filter_status')) + curses.A_REVERSE
@@ -3497,12 +3499,12 @@ class Interface:
                         pass
 
                 if self.selected and self.width - self.screen.getyx()[1] > 20:
-                    self.screen.addstr(strings[7] % len(self.selected), curses.A_REVERSE)
+                    self.screen.addstr(strings[7] % len(self.selected), curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE)
 
             else:
                 if self.details_category_focus == 1:
                     if gconfig.file_sort_key and self.width - self.screen.getyx()[1] > 20:
-                        self.screen.addstr(strings[6], curses.A_REVERSE)
+                        self.screen.addstr(strings[6], curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE)
                         name = [name[1] for name in gconfig.file_sort_options if name[0] == gconfig.file_sort_key][0]
                         name = name.replace('_', '').lower()
                         curses_tags = curses.color_pair(self.colors.ind('filter_status')) + curses.A_REVERSE
@@ -3512,9 +3514,9 @@ class Interface:
                             self.screen.addch(curses.ACS_UARROW, curses_tags)
                         self.screen.addstr(name[:10], curses_tags)
                     if self.width - self.screen.getyx()[1] > 20 and len(self.torrent_details['files']) > 1:
-                        self.screen.addstr(strings[8] % len(self.torrent_details['files']), curses.A_REVERSE)
+                        self.screen.addstr(strings[8] % len(self.torrent_details['files']), curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE)
                     if self.width - self.screen.getyx()[1] > 20 and self.selected_files:
-                        self.screen.addstr(strings[7] % len(self.selected_files), curses.A_REVERSE)
+                        self.screen.addstr(strings[7] % len(self.selected_files), curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE)
 
     def draw_global_rates(self):
         # ↑1.2K ↓3.4M
@@ -3534,30 +3536,30 @@ class Interface:
         if self.stats['alt-speed-enabled']:
             if self.narrow:
                 self.screen.move(self.height - 1, self.width - rates_width - limits_width - 1)
-                self.screen.addch(curses.ACS_TTEE, curses.A_REVERSE + curses.A_BOLD)
+                self.screen.addch(curses.ACS_TTEE, curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE + curses.A_BOLD)
             else:
                 self.screen.move(self.height - 1, self.width - rates_width - limits_width - len('Turtle mode '))
-                self.screen.addstr('Turtle mode ', curses.A_REVERSE + curses.A_BOLD)
+                self.screen.addstr('Turtle mode ', curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE + curses.A_BOLD)
 
         self.screen.move(self.height - 1, self.width - rates_width - limits_width)
-        self.screen.addch(curses.ACS_DARROW, curses.A_REVERSE)
+        self.screen.addch(curses.ACS_DARROW, curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE)
         self.screen.addstr(scale_bytes(self.stats['downloadSpeed']).rjust(self.rateDownload_width)[:self.rateDownload_width],
                            curses.color_pair(self.colors.ind('download_rate'))
                            + curses.A_BOLD)
-        self.screen.addstr(limits['dn_limit'], curses.A_REVERSE)
-        self.screen.addch(' ', curses.A_REVERSE)
-        self.screen.addch(curses.ACS_UARROW, curses.A_REVERSE)
+        self.screen.addstr(limits['dn_limit'], curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE)
+        self.screen.addch(' ', curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE)
+        self.screen.addch(curses.ACS_UARROW, curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE)
         try:
             self.screen.addstr(scale_bytes(self.stats['uploadSpeed']).rjust(self.rateUpload_width)[:self.rateUpload_width],
                                curses.color_pair(self.colors.ind('upload_rate'))
                                + curses.A_BOLD)
-            self.screen.addstr(limits['up_limit'], curses.A_REVERSE)
+            self.screen.addstr(limits['up_limit'], curses.color_pair(self.colors.ind('footer')) + curses.A_REVERSE)
         except curses.error:
             # curses can print to the last char (bottom right corner), but it raises an exception.
             pass
 
     def draw_title_bar(self):
-        self.screen.addstr(0, 0, ' '.center(self.width), curses.A_REVERSE)
+        self.screen.addstr(0, 0, ' '.center(self.width), curses.color_pair(self.colors.ind('header')) + curses.A_REVERSE)
         w = self.draw_connection_status()
         self.draw_quick_help(self.width - w - 2)
 
@@ -3566,7 +3568,7 @@ class Interface:
             status = "V.%s@%s:%s" % (self.server.version, gconfig.host, gconfig.port)
         else:
             status = "Transmission %s@%s:%s" % (self.server.version, gconfig.host, gconfig.port)
-        self.screen.addstr(0, 0, status, curses.A_REVERSE)
+        self.screen.addstr(0, 0, status, curses.color_pair(self.colors.ind('header')) + curses.A_REVERSE)
         return len(status)
 
     def draw_quick_help(self, maxwidth):
@@ -3596,7 +3598,7 @@ class Interface:
             t = "%s:%s" % (x[0], x[1])
             if len(line) + len(t) + 1 <= maxwidth:
                 line = line + ' ' + t
-        self.screen.addstr(0, self.width - len(line), line, curses.A_REVERSE)
+        self.screen.addstr(0, self.width - len(line), line, curses.color_pair(self.colors.ind('header')) + curses.A_REVERSE)
 
     def action_list_key_bindings(self):
         def key_name(k):

--- a/tremc
+++ b/tremc
@@ -420,6 +420,7 @@ config.set('Colors', 'selection', 'bg:default,fg:default')
 config.set('Colors', 'title_seed', 'bg:green,fg:black')
 config.set('Colors', 'title_download', 'bg:blue,fg:black')
 config.set('Colors', 'title_idle', 'bg:cyan,fg:black')
+config.set('Colors', 'title_incomplete', 'bg:default,fg:default')
 config.set('Colors', 'title_verify', 'bg:magenta,fg:black')
 config.set('Colors', 'title_paused', 'bg:default,fg:default')
 config.set('Colors', 'title_error', 'bg:red,fg:default')
@@ -2631,10 +2632,10 @@ class Interface:
         else:
             color = 0
 
-        tag = curses.A_REVERSE
+        tag = curses.color_pair(self.colors.ind('title_incomplete')) + curses.A_REVERSE
         tag_done = color
         if focused:
-            tag += curses.color_pair(self.colors.ind('selection'))
+            tag = curses.color_pair(self.colors.ind('selection')) + curses.A_REVERSE
             tag += curses.A_BOLD
             tag_done += curses.A_BOLD
 


### PR DESCRIPTION
Allows user to set some previously hardcoded ui colors.

| name | desc |
| ------ | ------ |
|header| top status line |
| footer | bottom status line |
| selection | selected items |
| title_incomplete | incomplete portion of title progressbar  |
| window | dialog window |

These default to `bg:default,fg:default` and still use `curses.A_REVERSE`, so the default colors for these should remain the same.
