### PR TITLE
A few bug fixes

### DIFF
--- a/tremc
+++ b/tremc
@@ -4537,6 +4537,7 @@ class Interface:
                     lines.append(', '.join([filter2string(f) for f in fl]) + ', ')
                     if lines[-1] == ', ':
                         lines[-1] = ''
+                        current[1] = 0
                     if i == current[0]:
                         commas = [i for i, v in enumerate(lines[-1]) if v == ',']
                         commas.append(len(lines[-1]) + 1)
@@ -4544,7 +4545,7 @@ class Interface:
                     i += 1
 
                 height = len(lines) + 3
-                width = min(max(len(s) for s in lines) + 6, self.width - 2)
+                width = min(max([14] + [len(s) for s in lines]) + 6, self.width - 2, )
                 if height > oldheight or width > oldwidth or win is None:
                     win = self.window(height, width, title='Filters')
                     oldheight, oldwidth = height, width
@@ -4572,7 +4573,7 @@ class Interface:
             if c == curses.KEY_LEFT and current[1] > 0:
                 current[1] -= 1
                 changed = True
-            if c == K.d and current[1] < len(filters[current[0]]):
+            if c in (K.d, curses.KEY_DC) and current[1] < len(filters[current[0]]):
                 filters[current[0]].pop(current[1])
                 changed = True
             if c == K.f:

--- a/tremc
+++ b/tremc
@@ -828,7 +828,7 @@ class Transmission:
 
             # resolve and locate peer's ip
             if gconfig.rdns and ip not in self.hosts_cache:
-                threading.Thread(target=reverse_dns, args=(self.hosts_cache, ip)).start()
+                threading.Thread(target=reverse_dns, args=(self.hosts_cache, ip), daemon=True).start()
             if gconfig.geoip and ip not in self.geo_ips_cache:
                 self.geo_ips_cache[ip] = country_code_by_addr_vany(self.geo_ip, self.geo_ip6, ip)
 

--- a/tremc
+++ b/tremc
@@ -3092,7 +3092,7 @@ class Interface:
             if gconfig.file_sort_key in ['name', 'length', 'bytesCompleted']:
                 self.sorted_files = sorted(self.torrent_details['files'], key=lambda x: x[gconfig.file_sort_key], reverse=gconfig.file_sort_reverse)
             elif gconfig.file_sort_key == 'progress':
-                self.sorted_files = sorted(self.torrent_details['files'], key=lambda x: x['bytesCompleted'] / x['length'], reverse=gconfig.file_sort_reverse)
+                self.sorted_files = sorted(self.torrent_details['files'], key=lambda x: x['bytesCompleted'] / x['length'] if x['length'] > 0 else 0, reverse=gconfig.file_sort_reverse)
             else:
                 if gconfig.file_sort_reverse:
                     self.sorted_files = list(reversed(self.torrent_details['files']))

--- a/tremc
+++ b/tremc
@@ -4537,7 +4537,8 @@ class Interface:
                     lines.append(', '.join([filter2string(f) for f in fl]) + ', ')
                     if lines[-1] == ', ':
                         lines[-1] = ''
-                        current[1] = 0
+                        if current[0] == len(lines) - 1:
+                            current[1] = 0
                     if i == current[0]:
                         commas = [i for i, v in enumerate(lines[-1]) if v == ',']
                         commas.append(len(lines[-1]) + 1)


### PR DESCRIPTION
This PR fixes a few bugs:

* Fix filter list edit dialog.
* Fix divide by zero when files aresorted by progress and a file has length zero.
* Daemonize rDNS threads: fow each peer, thread is started in order to query its reverse DNS name. this query might take a long time (depending on the DNS setup by the ISP of the peer). When quitting the program shortly after entering details view of a torrent, tremc will not exit until all threads complete. Daemonizing the threads avoids waiting for them on exit.