### PR TITLE
permit RPC version 17

### DIFF
--- a/tremc
+++ b/tremc
@@ -56,7 +56,7 @@ class GConfig:
     TRNSM_VERSION_MIN = '1.90'
     TRNSM_VERSION_MAX = '3.0.0'
     RPC_VERSION_MIN = 8
-    RPC_VERSION_MAX = 16
+    RPC_VERSION_MAX = 17
 
     STARTTIME = time.time()
     DEBUG = False


### PR DESCRIPTION
Fixes #118 

Fedora 37 recently updated transmission to 4.0.0 which broke tremc. Finding #118 here I updated tremc accordingly which made it work again.