### PR TITLE
Allow transmission-4.1.1 / RPC 19, no incompatible changes from 4.1.0 / 18

### DIFF
--- a/tremc
+++ b/tremc
@@ -187,9 +187,9 @@ class GConfig:
     VERSION = '0.9.5'
 
     TRNSM_VERSION_MIN = '1.90'
-    TRNSM_VERSION_MAX = '4.1'
+    TRNSM_VERSION_MAX = '4.1.1'
     RPC_VERSION_MIN = 8
-    RPC_VERSION_MAX = 18
+    RPC_VERSION_MAX = 19
 
     STARTTIME = time.time()
     DEBUG = False


### PR DESCRIPTION
4.1.1 reverted a protocol change in 4.1.0, where some fields had inadvertently gone from integer to number. They're now back as integers like they were before.