### PR TITLE
Remove the local path when pasting an URL

### DIFF
--- a/tremc
+++ b/tremc
@@ -1840,6 +1840,9 @@ class Interface:
                                           homedir2tilde(os.getcwd() + os.sep), tab_complete='files')
 
         if location:
+            # Remove the local path when pasting an URL
+            if location.startswith(homedir2tilde(os.getcwd() + os.sep)) and ('://' in location):
+                location = location[len(homedir2tilde(os.getcwd() + os.sep)):]
             if re.match('^[0-9a-fA-F]{40}$', location):
                 location = 'magnet:?xt=urn:btih:{}'.format(location)
 


### PR DESCRIPTION
Improve convenience to easily drop URLs without needing to manually strip the local path.